### PR TITLE
Fixes changed objects nested in arrays getting completely replaced.

### DIFF
--- a/JsonDiffPatch/JsonDiffer.cs
+++ b/JsonDiffPatch/JsonDiffer.cs
@@ -169,6 +169,23 @@ namespace JsonDiffPatch
 
             var leftMiddle = array1.Skip(commonHead).Take(array1.Length - commonTail - commonHead).ToArray();
             var rightMiddle = array2.Skip(commonHead ).Take(array2.Length - commonTail - commonHead).ToArray();
+
+            // Just a replace of values!
+            if (leftMiddle.Length == rightMiddle.Length)
+            {
+                for (int i = 0; i < leftMiddle.Length; i++)
+                {
+                    foreach (var operation in CalculatePatch(leftMiddle[i], rightMiddle[i], useIdPropertyToDetermineEquality, path + "/" + commonHead))
+                    {
+                        yield return operation;
+                    }
+                }
+
+                yield break;
+            }
+
+            
+
             foreach (var jToken in leftMiddle)
             {
                 yield return new RemoveOperation()

--- a/JsonDiffPatchTests/DiffTests.cs
+++ b/JsonDiffPatchTests/DiffTests.cs
@@ -74,7 +74,7 @@ namespace Tavis.JsonPatch.Tests
             TestName = "JsonPatch handles same array containing objects")]
         [TestCase("{a:[1,2,3,{name:'a'},4,5]}",
           "{a:[1,2,3,{name:'b'},4,5]}",
-          ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a/3\",\"value\":{\"name\":\"b\"}}]",
+          ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a/3/name\",\"value\":\"b\"}]",
           TestName = "Replaces array items")]
         [TestCase("{a:[]}",
           "{a:[]}",


### PR DESCRIPTION
I had the issue that an object inside an array was getting fully replaced instead of pin point patching a single changed value inside that object. This fixes it.