### PR TITLE
Improved Id equality check

### DIFF
--- a/JsonDiffPatch/CompareOptions.cs
+++ b/JsonDiffPatch/CompareOptions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace JsonDiffPatch
+{
+    public class CompareOptions
+    {
+        public static readonly CompareOptions Default = new CompareOptions();
+
+        public bool EnableIdentifierCheck { get; }
+        public string IdentifierProperty { get; }
+
+        public CompareOptions(bool enableIdentifierCheck = false, string identifierProperty = "id")
+        {
+            EnableIdentifierCheck = enableIdentifierCheck;
+            IdentifierProperty = identifierProperty;
+        }
+    }
+}

--- a/JsonDiffPatchTests/DiffTests2.cs
+++ b/JsonDiffPatchTests/DiffTests2.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Reflection;
 using JsonDiffPatch;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -10,25 +12,80 @@ namespace Tavis.JsonPatch.Tests
         [Test]
         public void ComplexExampleWithDeepArrayChange()
         {
-            
-            var leftPath = @".\samples\scene{0}a.json";
-            var rightPath = @".\samples\scene{0}b.json";
+            var currentDir = Path.GetDirectoryName(Assembly.GetCallingAssembly().CodeBase);
+            var leftPath = Path.Combine(currentDir, @"Samples\scene{0}a.json").Replace("file://", "").Replace("file:\\", "");
+            var rightPath = Path.Combine(currentDir, @"Samples\scene{0}b.json").Replace("file://", "").Replace("file:\\", "");
             var i = 1;
+            var filesFound = false;
             while(File.Exists(string.Format(leftPath, i)))
             {
+                filesFound = true;
+
                 var scene1Text = File.ReadAllText(string.Format(leftPath, i));
                 var scene1 = JToken.Parse(scene1Text);
                 var scene2Text = File.ReadAllText(string.Format(rightPath, i));
                 var scene2 = JToken.Parse(scene2Text);
-                var patchDoc = new JsonDiffer().Diff(scene1, scene2, true);
+                var patchDoc = new JsonDiffer().Diff(scene1, scene2, new CompareOptions(true));
                 //Assert.AreEqual("[{\"op\":\"remove\",\"path\":\"/items/0/entities/1\"}]",
                 var patcher = new JsonPatcher();
                 patcher.Patch(ref scene1, patchDoc);
                 Assert.True(JToken.DeepEquals(scene1, scene2));
                 i++;
             }
+
+            Assert.IsTrue(filesFound);
         }
 
+        [Test]
+        public void ComplexExampleWithDeepArrayChangeOtherIdProperty()
+        {
+            var currentDir = Path.GetDirectoryName(Assembly.GetCallingAssembly().CodeBase);
+            var leftPath = Path.Combine(currentDir, @"Samples\scene{0}a_otherid.json").Replace("file://", "").Replace("file:\\", "");
+            var rightPath = Path.Combine(currentDir, @"Samples\scene{0}b_otherid.json").Replace("file://", "").Replace("file:\\", "");
+            var i = 1;
+            var filesFound = false;
+            while (File.Exists(Path.Combine(currentDir, string.Format(leftPath, i))))
+            {
+                filesFound = true;
 
+                var scene1Text = File.ReadAllText(Path.Combine(currentDir, string.Format(leftPath, i)));
+                var scene1 = JToken.Parse(scene1Text);
+                var scene2Text = File.ReadAllText(Path.Combine(currentDir, string.Format(rightPath, i)));
+                var scene2 = JToken.Parse(scene2Text);
+                var patchDoc = new JsonDiffer().Diff(scene1, scene2, new CompareOptions(true, "otherId"));
+                var patcher = new JsonPatcher();
+                patcher.Patch(ref scene1, patchDoc);
+                Assert.True(JToken.DeepEquals(scene1, scene2));
+                i++;
+            }
+
+            Assert.IsTrue(filesFound);
+        }
+
+        [Test]
+        public void ComplexExampleWithDeepArrayChangeComplexIdProperty()
+        {
+            var currentDir = Path.GetDirectoryName(Assembly.GetCallingAssembly().CodeBase);
+            var leftPath = Path.Combine(currentDir, @"Samples\scene{0}a_complex_id.json").Replace("file://", "").Replace("file:\\", "");
+            var rightPath = Path.Combine(currentDir, @"Samples\scene{0}b_complex_id.json").Replace("file://", "").Replace("file:\\", "");
+            var i = 1;
+            var filesFound = false;
+            while (File.Exists(string.Format(leftPath, i)))
+            {
+                filesFound = true;
+
+                var scene1Text = File.ReadAllText(string.Format(leftPath, i));
+                var scene1 = JToken.Parse(scene1Text);
+                var scene2Text = File.ReadAllText(string.Format(rightPath, i));
+                var scene2 = JToken.Parse(scene2Text);
+                var patchDoc = new JsonDiffer().Diff(scene1, scene2, new CompareOptions(true));
+                var patcher = new JsonPatcher();
+                patcher.Patch(ref scene1, patchDoc);
+                Assert.True(JToken.DeepEquals(scene1, scene2));
+                i++;
+            }
+
+            Assert.IsTrue(filesFound);
+        }
     }
 }

--- a/JsonDiffPatchTests/JsonDiffPatch.Tests.csproj
+++ b/JsonDiffPatchTests/JsonDiffPatch.Tests.csproj
@@ -7,21 +7,83 @@
   <ItemGroup>
     <None Remove="Samples\LoadTest1.json" />
     <None Remove="Samples\scene1a.json" />
+    <None Remove="Samples\scene1a_complex_id.json" />
+    <None Remove="Samples\scene1a_otherid.json" />
     <None Remove="Samples\scene1b.json" />
+    <None Remove="Samples\scene1b_complex_id.json" />
+    <None Remove="Samples\scene1b_otherid.json" />
     <None Remove="Samples\scene2a.json" />
+    <None Remove="Samples\scene2a_complex_id.json" />
+    <None Remove="Samples\scene2a_otherid.json" />
     <None Remove="Samples\scene2b.json" />
+    <None Remove="Samples\scene2b_complex_id.json" />
+    <None Remove="Samples\scene2b_otherid.json" />
     <None Remove="Samples\scene3a.json" />
+    <None Remove="Samples\scene3a_complex_id.json" />
+    <None Remove="Samples\scene3a_otherid.json" />
     <None Remove="Samples\scene3b.json" />
+    <None Remove="Samples\scene3b_complex_id.json" />
+    <None Remove="Samples\scene3b_otherid.json" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Samples\LoadTest1.json" />
-    <EmbeddedResource Include="Samples\scene1a.json" />
-    <EmbeddedResource Include="Samples\scene1b.json" />
-    <EmbeddedResource Include="Samples\scene2a.json" />
-    <EmbeddedResource Include="Samples\scene2b.json" />
-    <EmbeddedResource Include="Samples\scene3a.json" />
-    <EmbeddedResource Include="Samples\scene3b.json" />
+    <EmbeddedResource Include="Samples\LoadTest1.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene1a_complex_id.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene1a_otherid.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene1a.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene1b_complex_id.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene1b_otherid.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene1b.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene2a_complex_id.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene2a_otherid.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene2a.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene2b_complex_id.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene2b_otherid.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene2b.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene3a_complex_id.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene3a_otherid.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene3a.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene3b_complex_id.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene3b_otherid.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Samples\scene3b.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonDiffPatchTests/Samples/scene1a_complex_id.json
+++ b/JsonDiffPatchTests/Samples/scene1a_complex_id.json
@@ -1,0 +1,19 @@
+﻿{
+  "items": [
+    {
+      "id": {
+        "external": "viewpoint",
+        "internal": "1234"
+      },
+      "entities": [
+        {
+          "name": "Donn Crimmins (sdf)"
+        },
+        {
+          "name": "Chester Westberg"
+        }
+      ],
+      "type": "Viewpoint"
+    }
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene1a_otherid.json
+++ b/JsonDiffPatchTests/Samples/scene1a_otherid.json
@@ -1,0 +1,16 @@
+﻿{
+  "items": [
+    {
+      "otherId": "viewpoint",
+      "entities": [
+        {
+          "name": "Donn Crimmins (sdf)"
+        },
+        {
+          "name": "Chester Westberg"
+        }
+      ],
+      "type": "Viewpoint"
+    }
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene1b_complex_id.json
+++ b/JsonDiffPatchTests/Samples/scene1b_complex_id.json
@@ -1,0 +1,16 @@
+﻿{
+  "items": [
+    {
+      "id": {
+        "internal": "1234",
+        "external": "viewpoint"
+      },
+      "entities": [
+        {
+          "name": "Donn Crimmins (sdf)"
+        }
+      ],
+      "type": "Viewpoint"
+    }
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene1b_otherid.json
+++ b/JsonDiffPatchTests/Samples/scene1b_otherid.json
@@ -1,0 +1,13 @@
+﻿{
+  "items": [
+    {
+      "otherId": "viewpoint",
+      "entities": [
+        {
+          "name": "Donn Crimmins (sdf)"
+        }
+      ],
+      "type": "Viewpoint"
+    }
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene2a_complex_id.json
+++ b/JsonDiffPatchTests/Samples/scene2a_complex_id.json
@@ -1,0 +1,13 @@
+﻿{
+  "incidents": [
+    {
+      "when": "2015-09-08T12:15:25+01:00",
+      "id": { "internal": "7f468da7-3788-40c0-90fd-b06bc61c86dd" },
+      "where": "Fey St",
+      "what": [
+        "Franklyn Sanfilippo (aaaa) says \"1\""
+      ],
+      "type": "Incident"
+    }
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene2a_otherid.json
+++ b/JsonDiffPatchTests/Samples/scene2a_otherid.json
@@ -1,0 +1,13 @@
+﻿{
+  "incidents": [
+    {
+      "when": "2015-09-08T12:15:25+01:00",
+      "otherId": "7f468da7-3788-40c0-90fd-b06bc61c86dd",
+      "where": "Fey St",
+      "what": [
+        "Franklyn Sanfilippo (aaaa) says \"1\""
+      ],
+      "type": "Incident"
+    }
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene2b_complex_id.json
+++ b/JsonDiffPatchTests/Samples/scene2b_complex_id.json
@@ -1,0 +1,22 @@
+﻿{
+  "incidents": [
+    {
+      "when": "2015-09-08T12:15:46+01:00",
+      "id": "dab4a570-2dde-458e-92b1-f71e42605f90",
+      "where": "Fey St",
+      "what": [
+        "Franklyn Sanfilippo (aaaa) says \"2\""
+      ],
+      "type": "Incident"
+    },
+    {
+      "when": "2015-09-08T12:15:25+01:00",
+      "id": { "internal": "7f468da7-3788-40c0-90fd-b06bc61c86dd" },
+      "where": "Fey St",
+      "what": [
+        "Franklyn Sanfilippo (aaaa) says \"1\""
+      ],
+      "type": "Incident"
+    }
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene2b_otherid.json
+++ b/JsonDiffPatchTests/Samples/scene2b_otherid.json
@@ -1,0 +1,22 @@
+﻿{
+  "incidents": [
+    {
+      "when": "2015-09-08T12:15:46+01:00",
+      "otherId": "dab4a570-2dde-458e-92b1-f71e42605f90",
+      "where": "Fey St",
+      "what": [
+        "Franklyn Sanfilippo (aaaa) says \"2\""
+      ],
+      "type": "Incident"
+    },
+    {
+      "when": "2015-09-08T12:15:25+01:00",
+      "otherId": "7f468da7-3788-40c0-90fd-b06bc61c86dd",
+      "where": "Fey St",
+      "what": [
+        "Franklyn Sanfilippo (aaaa) says \"1\""
+      ],
+      "type": "Incident"
+    }
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene3a_complex_id.json
+++ b/JsonDiffPatchTests/Samples/scene3a_complex_id.json
@@ -1,0 +1,6 @@
+﻿{
+  "description": [
+    "cash: 400",
+    "product: 100"
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene3a_otherid.json
+++ b/JsonDiffPatchTests/Samples/scene3a_otherid.json
@@ -1,0 +1,6 @@
+﻿{
+  "description": [
+    "cash: 400",
+    "product: 100"
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene3b_complex_id.json
+++ b/JsonDiffPatchTests/Samples/scene3b_complex_id.json
@@ -1,0 +1,6 @@
+﻿{
+  "description": [
+    "cash: 700",
+    "product: 000"
+  ]
+}

--- a/JsonDiffPatchTests/Samples/scene3b_otherid.json
+++ b/JsonDiffPatchTests/Samples/scene3b_otherid.json
@@ -1,0 +1,6 @@
+﻿{
+  "description": [
+    "cash: 700",
+    "product: 000"
+  ]
+}


### PR DESCRIPTION
Id equality in elements used to only be able to match on an 'id'
property. The functionality has been changed to configure the property
to compare equality.
Also the equality check used to only allow comparison of simple types.
This has been improved to compare complex 'id' objects.