### PR TITLE
Fix incorrect PatchDocument on diff

### DIFF
--- a/JsonDiffPatch/JsonDiffer.cs
+++ b/JsonDiffPatch/JsonDiffer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -79,8 +78,8 @@ namespace JsonDiffPatch
             }
             else if (left.Type == JTokenType.Object)
             {
-                var lprops = ((IDictionary<string, JToken>) left).OrderBy(p => p.Key);
-                var rprops = ((IDictionary<string, JToken>) right).OrderBy(p => p.Key);
+                var lprops = ((IDictionary<string, JToken>)left).OrderBy(p => p.Key);
+                var rprops = ((IDictionary<string, JToken>)right).OrderBy(p => p.Key);
 
                 foreach (var removed in lprops.Except(rprops, MatchesKey.Instance))
                 {
@@ -93,7 +92,7 @@ namespace JsonDiffPatch
                 }
 
                 var matchedKeys = lprops.Select(x => x.Key).Intersect(rprops.Select(y => y.Key));
-                var zipped = matchedKeys.Select(k => new {key = k, left = left[k], right = right[k]});
+                var zipped = matchedKeys.Select(k => new { key = k, left = left[k], right = right[k] });
 
                 foreach (var match in zipped)
                 {
@@ -119,16 +118,13 @@ namespace JsonDiffPatch
         {
             var comparer = new CustomCheckEqualityComparer(useIdPropertyToDetermineEquality, new JTokenEqualityComparer());
 
-           
-
-
             int commonHead = 0;
             int commonTail = 0;
             var array1 = left.ToArray();
             var len1 = array1.Length;
             var array2 = right.ToArray();
             var len2 = array2.Length;
-        //    if (len1 == 0 && len2 ==0 ) yield break;
+            //    if (len1 == 0 && len2 ==0 ) yield break;
             while (commonHead < len1 && commonHead < len2)
             {
                 if (comparer.Equals(array1[commonHead], array2[commonHead]) == false) break;
@@ -139,11 +135,10 @@ namespace JsonDiffPatch
                     yield return operation;
                 }
                 commonHead++;
-
             }
 
             // separate common tail
-            while (commonTail + commonHead < len1 && commonTail + commonHead < len2 )
+            while (commonTail + commonHead < len1 && commonTail + commonHead < len2)
             {
                 if (comparer.Equals(array1[len1 - 1 - commonTail], array2[len2 - 1 - commonTail]) == false) break;
 
@@ -166,16 +161,15 @@ namespace JsonDiffPatch
                 yield break;
             }
 
-
             var leftMiddle = array1.Skip(commonHead).Take(array1.Length - commonTail - commonHead).ToArray();
-            var rightMiddle = array2.Skip(commonHead ).Take(array2.Length - commonTail - commonHead).ToArray();
+            var rightMiddle = array2.Skip(commonHead).Take(array2.Length - commonTail - commonHead).ToArray();
 
             // Just a replace of values!
             if (leftMiddle.Length == rightMiddle.Length)
             {
                 for (int i = 0; i < leftMiddle.Length; i++)
                 {
-                    foreach (var operation in CalculatePatch(leftMiddle[i], rightMiddle[i], useIdPropertyToDetermineEquality, path + "/" + commonHead))
+                    foreach (var operation in CalculatePatch(leftMiddle[i], rightMiddle[i], useIdPropertyToDetermineEquality, $"{path}/{commonHead + i}"))
                     {
                         yield return operation;
                     }
@@ -184,21 +178,20 @@ namespace JsonDiffPatch
                 yield break;
             }
 
-            
-
             foreach (var jToken in leftMiddle)
             {
                 yield return new RemoveOperation()
                 {
-                    Path = new JsonPointer(path + "/" + (commonHead ))
+                    Path = new JsonPointer($"{path}/{commonHead}")
                 };
             }
+
             for (int i = 0; i < rightMiddle.Length; i++)
             {
                 yield return new AddOperation()
                 {
                     Value = rightMiddle[i],
-                    Path = new JsonPointer(path + "/" + (i + commonHead))
+                    Path = new JsonPointer($"{path}/{commonHead + i}")
                 };
             }
 
@@ -210,7 +203,7 @@ namespace JsonDiffPatch
             //        yield break;
             //    }
             //    // trivial case, a block (1 or more consecutive items) was added
-           
+
             //    for (index = commonHead; index < len2 - commonTail; index++)
             //    {
             //        yield return new AddOperation()
@@ -311,9 +304,6 @@ namespace JsonDiffPatch
             //    }
             //}
         }
-
-    
-  
 
         private class MatchesKey : IEqualityComparer<KeyValuePair<string, JToken>>
         {

--- a/JsonDiffPatchTests/DiffTests.cs
+++ b/JsonDiffPatchTests/DiffTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using JsonDiffPatch;
+﻿using JsonDiffPatch;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -68,22 +67,50 @@ namespace Tavis.JsonPatch.Tests
             "{a:[1,2,3,4]}",
             ExpectedResult = "[]",
             TestName = "JsonPatch handles same array")]
+
         [TestCase("{a:[1,2,3,{name:'a'}]}",
             "{a:[1,2,3,{name:'a'}]}",
             ExpectedResult = "[]",
             TestName = "JsonPatch handles same array containing objects")]
+
         [TestCase("{a:[1,2,3,{name:'a'},4,5]}",
           "{a:[1,2,3,{name:'b'},4,5]}",
           ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a/3/name\",\"value\":\"b\"}]",
           TestName = "Replaces array items")]
+
         [TestCase("{a:[]}",
           "{a:[]}",
           ExpectedResult = "[]",
           TestName = "Empty array gives no operations")]
+
         [TestCase("['a', 'b', 'c']",
             "['a', 'd', 'c']",
             ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/1\",\"value\":\"d\"}]"
             , TestName = "Inserts item in centre of array correctly")]
+
+        [TestCase(
+            "[1,4,5,6,2]",
+            "[1,3,4,5,2]",
+            ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/1\",\"value\":3},{\"op\":\"replace\",\"path\":\"/2\",\"value\":4},{\"op\":\"replace\",\"path\":\"/3\",\"value\":5}]"
+            , TestName = "Replaces items in middle of int array")]
+
+        [TestCase(
+            "[\"1\",\"4\",\"5\",\"6\",\"2\"]",
+            "[\"1\",\"3\",\"4\",\"5\",\"2\"]",
+            ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/1\",\"value\":\"3\"},{\"op\":\"replace\",\"path\":\"/2\",\"value\":\"4\"},{\"op\":\"replace\",\"path\":\"/3\",\"value\":\"5\"}]"
+            , TestName = "Replaces items in middle of string array")]
+
+        [TestCase(
+            "[{\"prop\":\"1\"},{\"prop\":\"4\"},{\"prop\":\"5\"},{\"prop\":\"6\"},{\"prop\":\"2\"}]",
+            "[{\"prop\":\"1\"},{\"prop\":\"3\"},{\"prop\":\"4\"},{\"prop\":\"5\"},{\"prop\":\"2\"}]",
+            ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/1/prop\",\"value\":\"3\"},{\"op\":\"replace\",\"path\":\"/2/prop\",\"value\":\"4\"},{\"op\":\"replace\",\"path\":\"/3/prop\",\"value\":\"5\"}]"
+            , TestName = "Replaces items in middle of complex objects array")]
+
+        [TestCase(
+            "[1,4,5,6,2]",
+            "[1,3,4,5,7,2]",
+            ExpectedResult = "[{\"op\":\"remove\",\"path\":\"/1\"},{\"op\":\"remove\",\"path\":\"/1\"},{\"op\":\"replace\",\"path\":\"/1\",\"value\":3},{\"op\":\"add\",\"path\":\"/2\",\"value\":4},{\"op\":\"add\",\"path\":\"/3\",\"value\":5},{\"op\":\"add\",\"path\":\"/4\",\"value\":7}]"
+            , TestName = "Manipulates items in middle of int array with different length")]
 
         //[TestCase("{a:[1,2,3,{name:'a'}]}",
         //    "{a:[1,2,3,{name:'b'}]}",


### PR DESCRIPTION
When diffing the following json arrays:
- Original: `[1,2,3,4,5,6,7,10,11,12,8]`
- New: `[1,2,3,4,5,6,7,9,10,11,8]`

The expected outcome is `[1,2,3,4,5,6,7,9,10,11,8]`, but the actual outcome turned out to be `[1,2,3,4,5,6,7,11,11,12,8]`. This incorrect outcome also occurs on different variants of the json array (see additional unit tests).

This pull request fixes this issue.