### PR TITLE
fix: correctly handle keys with slashes and tildes

### DIFF
--- a/JsonDiffPatch/AddOperation.cs
+++ b/JsonDiffPatch/AddOperation.cs
@@ -21,7 +21,8 @@ namespace JsonDiffPatch
 
         public override void Read(JObject jOperation)
         {
-            Path = new JsonPointer((string)jOperation.GetValue("path"));
+
+            Path = new JsonPointer(SplitPath((string)jOperation.GetValue("path")));
             Value = jOperation.GetValue("value");
         }
     }

--- a/JsonDiffPatch/CopyOperation.cs
+++ b/JsonDiffPatch/CopyOperation.cs
@@ -21,8 +21,8 @@ namespace JsonDiffPatch
 
         public override void Read(JObject jOperation)
         {
-            Path = new JsonPointer((string)jOperation.GetValue("path"));
-            FromPath = new JsonPointer((string)jOperation.GetValue("from"));
+            Path = new JsonPointer(SplitPath((string)jOperation.GetValue("path")));
+            FromPath = new JsonPointer(SplitPath((string)jOperation.GetValue("from")));
         }
     }
 }

--- a/JsonDiffPatch/JsonPatcher.cs
+++ b/JsonDiffPatch/JsonPatcher.cs
@@ -9,6 +9,7 @@ namespace JsonDiffPatch
 
         protected override JToken Replace(ReplaceOperation operation, JToken target)
         {
+            operation.Path.ToString().Replace("~1", "/").Replace("~0", "~");
             var token = operation.Path.Find(target);
             if (token.Parent == null)
             {
@@ -27,7 +28,7 @@ namespace JsonDiffPatch
             JObject parenttoken = null;
             var parentPath = operation.Path.ParentPointer.ToString();
             int index = parentPath == "/" ? parentPath.Length : parentPath.Length + 1;
-            var propertyName = operation.Path.ToString().Substring(index);
+            var propertyName = operation.Path.ToString().Substring(index).Replace("~1", "/").Replace("~0", "~");
             try
             {
                 var parentArray = operation.Path.ParentPointer.Find(target) as JArray;
@@ -63,7 +64,7 @@ namespace JsonDiffPatch
             else if (token is JArray)
             {
                 var array = token as JArray;
-                
+
                 array.Add(operation.Value);
             }
             else if (token.Parent is JProperty)

--- a/JsonDiffPatch/MoveOperation.cs
+++ b/JsonDiffPatch/MoveOperation.cs
@@ -21,8 +21,8 @@ namespace JsonDiffPatch
 
         public override void Read(JObject jOperation)
         {
-            Path = new JsonPointer((string)jOperation.GetValue("path"));
-            FromPath = new JsonPointer((string)jOperation.GetValue("from"));
+            Path = new JsonPointer(SplitPath((string)jOperation.GetValue("path")));
+            FromPath = new JsonPointer(SplitPath((string)jOperation.GetValue("from")));
         }
     }
 }

--- a/JsonDiffPatch/Operation.cs
+++ b/JsonDiffPatch/Operation.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Tavis;
 
@@ -32,6 +33,8 @@ namespace JsonDiffPatch
             writer.WritePropertyName("value");
             value.WriteTo(writer);
         }
+
+        protected static string[] SplitPath(string path) => path.Split('/').Skip(1).ToArray();
 
         public abstract void Read(JObject jOperation);
 

--- a/JsonDiffPatch/RemoveOperation.cs
+++ b/JsonDiffPatch/RemoveOperation.cs
@@ -6,7 +6,7 @@ namespace JsonDiffPatch
 {
     public class RemoveOperation : Operation
     {
-        
+
         public override void Write(JsonWriter writer)
         {
             writer.WriteStartObject();
@@ -19,7 +19,7 @@ namespace JsonDiffPatch
 
         public override void Read(JObject jOperation)
         {
-            Path = new JsonPointer((string)jOperation.GetValue("path"));   
+            Path = new JsonPointer(SplitPath((string)jOperation.GetValue("path")));
         }
     }
 }

--- a/JsonDiffPatch/ReplaceOperation.cs
+++ b/JsonDiffPatch/ReplaceOperation.cs
@@ -21,7 +21,7 @@ namespace JsonDiffPatch
 
         public override void Read(JObject jOperation)
         {
-            Path = new JsonPointer((string)jOperation.GetValue("path"));
+            Path = new JsonPointer(SplitPath((string)jOperation.GetValue("path")));
             Value = jOperation.GetValue("value");
         }
     }

--- a/JsonDiffPatch/Tavis.JsonPointer/JsonPointer.cs
+++ b/JsonDiffPatch/Tavis.JsonPointer/JsonPointer.cs
@@ -15,7 +15,7 @@ namespace Tavis
             _Tokens = pointer.Split('/').Skip(1).Select(Decode).ToArray();
         }
 
-        private JsonPointer(string[] tokens)
+        internal JsonPointer(string[] tokens)
         {
             _Tokens = tokens;
         }
@@ -47,7 +47,7 @@ namespace Tavis
             try
             {
                 var pointer = sample;
-                foreach (var token in _Tokens)
+                foreach (var token in _Tokens.Select(t => t.Replace("~1", "/").Replace("~0", "~")))
                 {
                     if (pointer is JArray)
                     {

--- a/JsonDiffPatch/TestOperation.cs
+++ b/JsonDiffPatch/TestOperation.cs
@@ -21,7 +21,7 @@ namespace JsonDiffPatch
 
         public override void Read(JObject jOperation)
         {
-            Path = new JsonPointer((string)jOperation.GetValue("path"));
+            Path = new JsonPointer(SplitPath((string)jOperation.GetValue("path")));
             Value = jOperation.GetValue("value");
         }
     }

--- a/JsonDiffPatchTests/DiffTests.cs
+++ b/JsonDiffPatchTests/DiffTests.cs
@@ -112,10 +112,76 @@ namespace Tavis.JsonPatch.Tests
             ExpectedResult = "[{\"op\":\"remove\",\"path\":\"/1\"},{\"op\":\"remove\",\"path\":\"/1\"},{\"op\":\"replace\",\"path\":\"/1\",\"value\":3},{\"op\":\"add\",\"path\":\"/2\",\"value\":4},{\"op\":\"add\",\"path\":\"/3\",\"value\":5},{\"op\":\"add\",\"path\":\"/4\",\"value\":7}]"
             , TestName = "Manipulates items in middle of int array with different length")]
 
-        //[TestCase("{a:[1,2,3,{name:'a'}]}",
-        //    "{a:[1,2,3,{name:'b'}]}",
-        //    ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a/3/name\",\"value\":'b'}]",
-        //    TestName = "JsonPatch handles same array containing different objects")]
+        [TestCase(
+            "{a:{}}",
+            "{a:{'foo/bar':1337}}",
+            ExpectedResult = "[{\"op\":\"add\",\"path\":\"/a/foo~1bar\",\"value\":1337}]"
+            , TestName = "Adds a key containing a slash")]
+
+        [TestCase(
+            "{a:{}}",
+            "{a:{'foo~1bar':1337}}",
+            ExpectedResult = "[{\"op\":\"add\",\"path\":\"/a/foo~01bar\",\"value\":1337}]"
+            , TestName = "Adds a key containing a tilde")]
+
+        [TestCase(
+            "{a:{}}",
+            "{a:{'foo0~/1bar':1337}}",
+            ExpectedResult = "[{\"op\":\"add\",\"path\":\"/a/foo0~0~11bar\",\"value\":1337}]"
+            , TestName = "Adds a key containing a tilde and a slash")]
+
+        [TestCase(
+            "{a:{'foo/bar':42}}",
+            "{a:{'foo/bar':1337}}",
+            ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a/foo~1bar\",\"value\":1337}]"
+            , TestName = "Replaces a key containing a slash")]
+
+        [TestCase(
+            "{a:{'foo/bar':42}}",
+            "{a:{}}",
+            ExpectedResult = "[{\"op\":\"remove\",\"path\":\"/a/foo~1bar\"}]"
+            , TestName = "Remove a key containing a slash")]
+
+        [TestCase(
+            "{a:[]}",
+            "{a:[{'foo/bar':1337}]}",
+            ExpectedResult = "[{\"op\":\"add\",\"path\":\"/a/0\",\"value\":{\"foo/bar\":1337}}]"
+            , TestName = "Adds an object to an array that contains a slash in some property")]
+
+        [TestCase(
+            "{a:[{'foo/bar':1337}]}",
+            "{a:[]}",
+            ExpectedResult = "[{\"op\":\"remove\",\"path\":\"/a/0\"}]"
+            , TestName = "Remove an object to an array that contains a slash in some property")]
+
+        [TestCase(
+            "{a:[{},{'foo/bar':42}]}",
+            "{a:[{},{'foo/bar':1337}]}",
+            ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a/1/foo~1bar\",\"value\":1337}]"
+            , TestName = "Replace a value in an object in an array that contains a slash in some property")]
+
+        [TestCase(
+            "{a:[{'foo/bar':42}]}",
+            "{a:[{'foo/bar':1337}]}",
+            ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a\",\"value\":[{\"foo/bar\":1337}]}]"
+            , TestName = "Replace whole array that contains a slash in some property")]
+
+        [TestCase(
+            "{a:[{'foo~bar':42}]}",
+            "{a:[{'foo~bar':1337}]}",
+            ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a\",\"value\":[{\"foo~bar\":1337}]}]"
+            , TestName = "Replace whole array that contains a tilde in some property")]
+
+        [TestCase(
+            "{a:[{},{'foo~bar':42}]}",
+            "{a:[{},{'foo~bar':1337}]}",
+            ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a/1/foo~0bar\",\"value\":1337}]"
+            , TestName = "Replace a value in an object in an array that contains a tilde in some property")]
+
+        [TestCase("{a:[1,2,3,{name:'a'}]}",
+            "{a:[1,2,3,{name:'b'}]}",
+            ExpectedResult = "[{\"op\":\"replace\",\"path\":\"/a/3/name\",\"value\":\"b\"}]",
+            TestName = "JsonPatch handles same array containing different objects")]
         public string JsonPatchesWorks(string leftString, string rightString)
         {
             var left = JToken.Parse(leftString);


### PR DESCRIPTION
This fixes #13.
Basically, the names are correctly encoded during diff and unencoded while patching.

Tests are in place with add / remove / replace in objects and arrays.