### PR TITLE
Upgrade to netstandard2.0 instead of netcore and full .net framework.

### DIFF
--- a/JsonDiffPatch/JsonDiffPatch.csproj
+++ b/JsonDiffPatch/JsonDiffPatch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Library for diffing and RFC 6902 patching json.net json objects - forked from Tavis.JsonPatch, with an addition of json diff code by Ian Mercer, with additional partial array LCS diff by JC Dickinson</Description>
     <PackageLicenseUrl>https://github.com/mcintyre321/JsonDiffPatch/blob/master/License.txt</PackageLicenseUrl>
     <Copyright />
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/JsonDiffPatchTests/JsonDiffPatch.Tests.csproj
+++ b/JsonDiffPatchTests/JsonDiffPatch.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/JsonDiffPatchTests/JsonDiffPatch.Tests.csproj
+++ b/JsonDiffPatchTests/JsonDiffPatch.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,10 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Targetting netstandard1.x is not recommended by Microsoft anymore, as it is no longer maintained.

Microsoft now recommends to target netstandard2.0 if compatibility with .NET Framework is required.
https://devblogs.microsoft.com/dotnet/the-future-of-net-standard/#:~:text=Use%20netstandard2.0%20to%20share%20code%20between%20.NET%20Framework%20and%20all%20other%20platforms.

The impact is low, as only support for .NET Framework 4.5.x will be dropped

**Breaking change:** 
By updating to netstandard, net4.5 will no longer be supported. 